### PR TITLE
docs: fix the path of global-style

### DIFF
--- a/docs/1.getting-started/4.assets.md
+++ b/docs/1.getting-started/4.assets.md
@@ -79,7 +79,7 @@ export default defineNuxtConfig({
     css: {
       preprocessorOptions: {
         scss: {
-          additionalData: '@use "@/assets/_colors.scss" as *;'
+          additionalData: '@use "~/assets/_colors.scss" as *;'
         }
       }
     }
@@ -93,7 +93,7 @@ export default defineNuxtConfig({
     css: {
       preprocessorOptions: {
         sass: {
-          additionalData: '@use "@/assets/_colors.sass" as *\n'
+          additionalData: '@use "~/assets/_colors.sass" as *\n'
         }
       }
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
 👉 https://nuxt.com/docs/community/contribution
-->

### 🔗 Linked issue

The example path on the official website is incorrect, and global style variables cannot be introduced correctly
![image](https://github.com/xxhls/nuxt/assets/108137214/7e6c70cc-e57f-4dd0-ae7b-f1b329809077)


### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)

### 📚 Description

Changing @ to~is necessary to correctly implement the introduction.
![image](https://github.com/xxhls/nuxt/assets/108137214/f904a9e6-2f2e-4f48-9334-1592a2192cbb)

